### PR TITLE
fix: set dummy OPENAI_API_KEY fallback for custom providers and correct Ollama endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ codescanai --provider custom --host http://localhost --port 5000 --token your_to
 Using locally running [Ollama](https://github.com/ollama/ollama):
 
 ```bash
-codescanai --provider custom --model llama3 --host http://localhost --port 11434 --endpoint /api/generate --directory path/to/code
+codescanai --provider custom --model llama3 --host http://localhost --port 11434 --endpoint /v1 --directory path/to/code
 ```
 
 ### Supported arguments

--- a/core/code_scanner/agent_scanner.py
+++ b/core/code_scanner/agent_scanner.py
@@ -41,8 +41,9 @@ class AgentScanner:
             if args.endpoint:
                 host_url += args.endpoint
             os.environ["OPENAI_BASE_URL"] = host_url
-            if args.token:
-                os.environ["OPENAI_API_KEY"] = args.token
+            # The OpenAI SDK requires a non-empty API key even for local servers that
+            # don't authenticate. Fall back to a dummy value when no token is supplied.
+            os.environ["OPENAI_API_KEY"] = args.token if args.token else "dummy"
 
         self.agent = create_agent(
             model_str=model_str,


### PR DESCRIPTION
When using --provider custom without --token, the OpenAI SDK raises an error because OPENAI_API_KEY is unset even though local servers like Ollama don't require authentication. Sets a dummy fallback value so the SDK initialises cleanly.

Also corrects the README Ollama example from --endpoint /api/generate to --endpoint /v1 — Pydantic-AI uses the OpenAI SDK which appends /chat/completions to the base URL, so the OpenAI-compatible path (/v1) is required, not Ollama's native generate endpoint.

Fixes #59