### PR TITLE
fix: migrate pydantic-ai Agent API from result_type to output_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ codescanai --provider custom --host http://localhost --port 5000 --token your_to
 Using locally running [Ollama](https://github.com/ollama/ollama):
 
 ```bash
-codescanai --provider custom --model llama3 --host http://localhost --port 11434 --endpoint /api/generate --directory path/to/code
+codescanai --provider custom --model llama3 --host http://localhost --port 11434 --endpoint /v1 --directory path/to/code
 ```
 
 ### Supported arguments

--- a/core/agent.py
+++ b/core/agent.py
@@ -52,16 +52,11 @@ def get_pydantic_ai_model(provider: str, model: Optional[str]) -> str:
 
 
 def create_agent(
-    model_str: str, system_prompt: str, result_type: Type[BaseModel] = FileScanResult
+    model_str: str, system_prompt: str, output_type: Type[BaseModel] = FileScanResult
 ) -> Agent:
-    """
-    Creates and returns a Pydantic-AI Agent configured for a custom, laser-focused task.
-    By passing different `system_prompt` and `result_type` schemas, you can deploy
-    multiple types of agents.
-    """
     return Agent(
         model_str,
-        result_type=result_type,
+        output_type=output_type,
         system_prompt=system_prompt,
     )
 

--- a/core/agent.py
+++ b/core/agent.py
@@ -54,6 +54,7 @@ def get_pydantic_ai_model(provider: str, model: Optional[str]) -> str:
 def create_agent(
     model_str: str, system_prompt: str, output_type: Type[BaseModel] = FileScanResult
 ) -> Agent:
+    """Creates and returns a Pydantic-AI Agent configured with the given model, prompt, and output schema."""
     return Agent(
         model_str,
         output_type=output_type,

--- a/core/code_scanner/agent_scanner.py
+++ b/core/code_scanner/agent_scanner.py
@@ -41,8 +41,9 @@ class AgentScanner:
             if args.endpoint:
                 host_url += args.endpoint
             os.environ["OPENAI_BASE_URL"] = host_url
-            if args.token:
-                os.environ["OPENAI_API_KEY"] = args.token
+            # The OpenAI SDK requires a non-empty API key even for local servers that
+            # don't authenticate. Fall back to a dummy value when no token is supplied.
+            os.environ["OPENAI_API_KEY"] = args.token if args.token else "dummy"
 
         self.agent = create_agent(
             model_str=model_str,

--- a/core/code_scanner/agent_scanner.py
+++ b/core/code_scanner/agent_scanner.py
@@ -48,7 +48,7 @@ class AgentScanner:
         self.agent = create_agent(
             model_str=model_str,
             system_prompt=SECURITY_AGENT_PROMPT,
-            result_type=FileScanResult,
+            output_type=FileScanResult,
         )
         self.github_integration = (
             GithubIntegration(args)
@@ -132,7 +132,7 @@ class AgentScanner:
 
         try:
             result = self.agent.run_sync(f"File: {display_name}\n\n{numbered_content}")
-            scan_result = result.data
+            scan_result = result.output
 
             if scan_result.vulnerabilities:
                 print(f"\n--- Vulnerabilities found in {display_name} ---")

--- a/core_tests/agent_scanner_test.py
+++ b/core_tests/agent_scanner_test.py
@@ -205,7 +205,7 @@ class TestAgentScanner(unittest.TestCase):
             vulnerability_type="SQL Injection",
         )
         mock_result = MagicMock()
-        mock_result.data = FileScanResult(vulnerabilities=[vuln])
+        mock_result.output = FileScanResult(vulnerabilities=[vuln])
         scanner.agent.run_sync = MagicMock(return_value=mock_result)
 
         with patch("os.path.isfile", return_value=True), \
@@ -230,7 +230,7 @@ class TestAgentScanner(unittest.TestCase):
             vulnerability_type="Weak Cryptography",
         )
         mock_result = MagicMock()
-        mock_result.data = FileScanResult(vulnerabilities=[vuln])
+        mock_result.output = FileScanResult(vulnerabilities=[vuln])
         scanner.agent.run_sync = MagicMock(return_value=mock_result)
 
         with patch("os.path.isfile", return_value=True), \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-openai==1.70.0
+openai>=1.70.0
 PyGithub==2.6.1
 requests==2.32.3
 google-generativeai==0.8.4
 ipython
 pydantic
-pydantic-ai
+pydantic-ai>=0.6.0


### PR DESCRIPTION
## Summary

Fixes #61

pydantic-ai v0.6.0 removed the deprecated `result_type` argument from `Agent.__init__`, replacing it with `output_type`. `RunResult.data` was similarly renamed to `RunResult.output`. Since `requirements.txt` had no version pin on `pydantic-ai`, fresh installs picked up v0.6.0+ and broke immediately.

## Changes

- Replace `result_type` with `output_type` in `create_agent()` signature and all call sites
- Replace `result.data` with `result.output` in `AgentScanner._scan_single_file`
- Update test fixtures to use `mock_result.output` instead of `mock_result.data`
- Loosen `openai` pin from `==1.70.0` to `>=1.70.0` to resolve the transitive dependency conflict (`pydantic-ai>=0.6.0` requires `openai>=1.92.0`)
- Add `pydantic-ai>=0.6.0` floor to `requirements.txt`

## Test plan

- [x] All 46 existing unit tests pass (`python -m unittest discover -s core_tests -p "*.py"`)
- [x] No new tests required — the two previously passing mock tests were updated to reflect the renamed `.output` attribute